### PR TITLE
Add port to tempo configuration

### DIFF
--- a/tempo/tempo-config.yml
+++ b/tempo/tempo-config.yml
@@ -21,3 +21,10 @@ storage:
       path: /tmp/tempo/wal
     local:
       path: /tmp/tempo/blocks
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317


### PR DESCRIPTION
The otel collector logs were throwing connection refused when trying to hit tempo at 4317. This should enable receiving requests at that port for tempo so we can record traces.